### PR TITLE
Changed contents of gpii.packageKit context to be an array.

### DIFF
--- a/testData/solutions/linux.json
+++ b/testData/solutions/linux.json
@@ -438,10 +438,12 @@
                 "id": "linux",
                 "version": ">=2.6.26"
             }],
-            "gpii.packageKit": {
-                "name": "orca",
-                "version": ">=3.4"
-            }
+            "gpii.packageKit": [
+                {
+                    "name": "orca",
+                    "version": ">=3.4"
+                }
+            ]
         },
         "settingsHandlers": [
             {
@@ -1257,10 +1259,16 @@
                     "version": ">=2.6.26"
                 }
             ],
-            "gpii.packageKit": {
-                "name": "alsa",
-                "version": ">=1"
-            }
+            "gpii.packageKit": [
+                {
+                    "name": "alsa",
+                    "version": ">=1"
+                },
+                {
+                    "name": "alsa-lib",
+                    "version": ">=1"
+                }
+            ]
         },
         "settingsHandlers": [
             {


### PR DESCRIPTION
Each element of the array uses a different name for the same
software because the name is different for different
distributions.
