### PR TITLE
Device reporter draft2

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,33 @@
+{
+    "bitwise": false,
+    "camelcase": false,
+    "curly": true,
+    "eqeqeq": true,
+    "es3": true,
+    "forin": false,
+    "freeze": true,
+    "immed": true,
+    "indent": 4,
+    "latedef": true,
+    "newcap": true,
+    "noarg": true,
+    "noempty": false,
+    "nonbsp": true,
+    "nonew": true,
+    "plusplus": false,
+    "quotmark": "double",
+    "undef": true,
+    "unused": true,
+    "strict": true,
+    "trailing": true,
+
+    "maxerr": 1000,
+
+    "browser": true,
+    "jquery": true,
+    "worker": true,
+
+    "globals": {
+        "fluid_1_5": true
+    }
+}

--- a/gpii/node_modules/deviceReporter/configs/kettleModuleLoader.js
+++ b/gpii/node_modules/deviceReporter/configs/kettleModuleLoader.js
@@ -10,6 +10,8 @@ You may obtain a copy of the License at
 https://github.com/gpii/kettle/LICENSE.txt
 */
 
+/* global module, require */
+
 // The purpose of this file is to be copied to a location for which the
 // require function is needed. It allows to find node modules relative
 // to that location that are otherwise non-resolvable.

--- a/gpii/node_modules/deviceReporter/index.js
+++ b/gpii/node_modules/deviceReporter/index.js
@@ -1,3 +1,5 @@
+/* global require, __dirname */
+
 var fluid = require("infusion");
 
 var loader = fluid.getLoader(__dirname);

--- a/gpii/node_modules/deviceReporter/src/DeviceGet.js
+++ b/gpii/node_modules/deviceReporter/src/DeviceGet.js
@@ -10,14 +10,15 @@
  * https://github.com/gpii/universal/LICENSE.txt
  */
 
+/* global require */
+
 (function () {
 
     "use strict";
 
     var fluid = require("infusion"),
         os = require("os"),
-        gpii = fluid.registerNamespace("gpii"),
-        kettle = fluid.require("kettle", require);
+        gpii = fluid.registerNamespace("gpii");
 
     fluid.defaults("kettle.requests.request.handler.deviceGet", {
         gradeNames: ["fluid.littleComponent", "autoInit"],
@@ -43,10 +44,10 @@
 
            solutionsRegistryDataSource.get(null, function onSuccess(entries) {
                 entries.forEach( function (entry) {
-                    if (!installedSolutions.some(function(s) { return s.id == entry.id })) {
+                    if (!installedSolutions.some(function(s) { return s.id === entry.id; })) {
                         if (entry.contexts.deviceReporters) {
                             entry.contexts.deviceReporters.forEach( function (deviceReporter) {
-                                if (!installedSolutions.some(function(s) { return s.id == entry.id })) {
+                                if (!installedSolutions.some(function(s) { return s.id === entry.id; })) {
                                     if (fluid.invokeGlobalFunction(deviceReporter.type, [deviceReporter.name])) {
                                         installedSolutions.push({ "id": entry.id });
                                     }

--- a/gpii/node_modules/deviceReporter/src/DeviceReporter.js
+++ b/gpii/node_modules/deviceReporter/src/DeviceReporter.js
@@ -10,15 +10,17 @@ You may obtain a copy of the License at
 https://github.com/gpii/universal/LICENSE.txt
 */
 
+/* global require, __dirname */
+
 (function () {
 
     "use strict";
 
     var fluid = require("infusion"),
         path = require("path"),
-        os = require("os"),
-        gpii = fluid.registerNamespace("gpii");
+        os = require("os");
 
+    fluid.registerNamespace("gpii");
     fluid.require("kettle", require);
     fluid.require("./DeviceGet.js", require);
 


### PR DESCRIPTION
Javi,

This addresses Bosmon's first comment, and goes a bit further to fix all the jshint issues in the device reporter JS files.  Note that I only tested/fixed those JS files, not all of the JS files in "universal".  That should be done too, but that's a separate issue.

I have a concern about a couple of the changes I made.  I removed this line from DeviceGet.js, because jshint complained that kettle was defined but not used:
kettle = fluid.require("kettle", require);

Similarly, I removed the gpii variable from this line in DeviceReporter.js, since again jshint said gpii is defined but not used.
gpii = fluid.registerNamespace("gpii");

However, I left the call to fluid.registerNamespace("gpii") in the file in case it has needed side effects.

You should confirm those two changes are okay.

Thanks.
