### PR TITLE
Device reporter draft2

### DIFF
--- a/testData/solutions/linux.json
+++ b/testData/solutions/linux.json
@@ -314,7 +314,7 @@
                     "type": "gpii.packageKit.find",
                     "name": "gnome-shell"
                 }
-            ]3
+            ]
         },
         "settingsHandlers": [
             {


### PR DESCRIPTION
Hi Javi,

Here's a second attempt at providing "deviceReporters" based on your email comments.  However, ...

First, I still have no idea what to put for "GNOME Shell overrides" (org.gnome.shell.overrides).  The schema listed in linux.json as "org.gnome.shell.overrides", but running 'rpm -qf /usr/share/glib-2.0/schemas/org.gnome.shell.overrides.gschema.xml' returns "No such file or directory".

Second, I changed three of the deviceReporters all to 'gsettings-desktop-schemas', namely:
- GNOME Interface Settings (org.gnome.desktop.interface), 
- GNOME Assistive Technology - Screen Keyboard (org.gnome.desktop.a11y.applications.onscreen-keyboard) , and
  -- GNOME Shell Keyboard Settings (org.gnome.desktop.a11y.keyboard).

They were previously, 'gnome-themes-standard', 'caribou', and 'control-center', respectively.  The only one that bothers me is caribou, since if there is no on-screen keyboard installed, changing the gsetting will have no effect.  I'm wondering if that one should be 'gnome-shell'?

Anyhow, have a look and let me know.

Thanks.
