### PR TITLE
GPII-413: Use fluid.each() instead of Object.keys().

### DIFF
--- a/gpii/node_modules/deviceReporter/src/DeviceGet.js
+++ b/gpii/node_modules/deviceReporter/src/DeviceGet.js
@@ -43,16 +43,16 @@
         } else {
             var installedSolutions = [];
             solutionsRegistryDataSource.get(null, function onSuccess(entries) {
-                Object.keys(entries).forEach(function (entryId) {
-                    var entry = entries[entryId];
+                fluid.each(entries, function (entry, entryId) {
                     if (!installedSolutions.some(function (s) { return s.id === entryId; })) {
-                        fluid.each(entry.contexts.deviceReporters, function (deviceReporter) {
-                            if (!installedSolutions.some(function (s) { return s.id === entryId; })) {
-                                if (fluid.invokeGradedFunction(deviceReporter.type, deviceReporter)) {
-                                    installedSolutions.push({ "id": entryId });
-                                }
+                        var foundEntryId = fluid.find (entry.contexts.deviceReporters, function (deviceReporter) {
+                            if (fluid.invokeGradedFunction (deviceReporter.type, deviceReporter)) {
+                                return entryId;
                             }
-                        });
+                        }, null);
+                        if  (foundEntryId !== null) {
+                            installedSolutions.push ({ "id": foundEntryId });
+                        }
                     }
                 });
                 requestProxy.events.onSuccess.fire({


### PR DESCRIPTION
@javihernandez I discovered that fluid.each() works with plain objects, and decided to rewrite part of DeviceGet.js to use it instead of Object.keys().  In the process, I tried to clean up the logic of that section using fluid.find() instead multiple calls to installedSolutions.some().

Let me know what you think, thanks.
