### PR TITLE
GPII-3461: Applying SPI first, so it doesn't overwrite our registry setting.

### DIFF
--- a/testData/snapshots/defaultSettings.win32.json5
+++ b/testData/snapshots/defaultSettings.win32.json5
@@ -124,12 +124,12 @@
             }
         },
         "configure": [
+            "settings.configure-spi",
             "settings.configure-registry",
             {
                 "type": "gpii.windows.spiSettingsHandler.setHighContrastTheme",
                 "filename": "${{registry}HKEY_CURRENT_USER\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Themes\\LastHighContrastTheme}"
-            },
-            "settings.configure-spi"
+            }
         ],
         "isInstalled": [{
             "type": "gpii.deviceReporter.alwaysInstalled"


### PR DESCRIPTION
We set the theme using  the `settings.configure-registry` and `setHighContrastTheme` configuration blocks, but I think `settings.configure-spi` over-writes them.

I've changed the order in which they are applied - this should now turn off high-contrast, then set the theme. Because the theme is now being set *after* high-contrast is set, it will only make sense if it will be getting turned off.


